### PR TITLE
Generate an OSGi bundle rather than a plain jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,16 +3,39 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.jfree.chart</groupId>
   <artifactId>jfreechart-fse</artifactId>
-  <packaging>jar</packaging>
+  <packaging>bundle</packaging>
   <version>1.0-SNAPSHOT</version>
   <name>jfreechart-fse</name>
   <url>http://maven.apache.org</url>
+ 
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <!-- used as Bundle-Version in bnd.properties -->
+    <jfreechart.bundle.version>1.0.20.SNAPSHOT</jfreechart.bundle.version>
+  </properties>
+
   <build>
     <resources>
       <resource>
         <directory>src/main/resources</directory>
       </resource>
     </resources>
+    <!-- Use maven-bundle-plugin in order to generate OSGi metadata -->
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>2.3.7</version>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <!-- include src/bnd.properties which has all Bnd
+                 instructions -->
+            <_include>src/bnd.properties</_include>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
   <dependencies>
     <dependency>

--- a/src/bnd.properties
+++ b/src/bnd.properties
@@ -1,0 +1,8 @@
+Bundle-Name= JFreeChart is a free 100% Java chart library 
+Bundle-SymbolicName= org.jfree.jfreechart
+Bundle-Version= ${jfreechart.bundle.version}
+# Export all packages except javax*
+Export-Package=!javax*,*
+Import-Package=*;resolution:=optional
+# Don't generate uses clauses
+-nouses=true


### PR DESCRIPTION
This will generate OSGi metadata so that jfreechart can be used in an
OSGi environment as well.

Changed packaging type to bundle = jar + OSGi metadata.
