### PR TITLE
Quick gradient fix for GradientBarPainter

### DIFF
--- a/src/main/java/org/jfree/chart/renderer/category/GradientBarPainter.java
+++ b/src/main/java/org/jfree/chart/renderer/category/GradientBarPainter.java
@@ -157,7 +157,7 @@ public class GradientBarPainter implements BarPainter, Serializable {
                     this.g3);
             GradientPaint gp = new GradientPaint(0.0f,
                     (float) regions[0].getMinY(), c0, 0.0f,
-                    (float) regions[0].getMaxX(), Color.WHITE);
+                    (float) regions[0].getMaxY(), Color.WHITE);
             g2.setPaint(gp);
             g2.fill(regions[0]);
 


### PR DESCRIPTION
Hi,

GradientBarPainter uses maxX instead of maxY for the first region of a top-down gradient, which gives the wrong result (most of the time, no gradient at all since the X range is much larger than the Y range). Using getMaxY() instead gives a correct gradient for the first region.

Regards,

Stephen
