### PR TITLE
Fix bug 1084 - throw an exception if the wrong object is used for an edg...

### DIFF
--- a/src/main/java/org/jfree/chart/block/BorderArrangement.java
+++ b/src/main/java/org/jfree/chart/block/BorderArrangement.java
@@ -87,7 +87,9 @@ public class BorderArrangement implements Arrangement, Serializable {
     }
 
     /**
-     * Adds a block to the arrangement manager at the specified edge.
+     * Adds a block to the arrangement manager at the specified edge. If
+     * the specified object is not an edge (or null), the method throws an
+     * <tt>IllegalArgumentException</tt>
      *
      * @param block  the block (<code>null</code> permitted).
      * @param key  the edge (an instance of {@link RectangleEdge}) or
@@ -98,8 +100,10 @@ public class BorderArrangement implements Arrangement, Serializable {
 
         if (key == null) {
             this.centerBlock = block;
-        }
-        else {
+        } else if (!(key instanceof RectangleEdge)) {
+        	throw new IllegalArgumentException("The specified edge must be a " +
+        			"RectangleEdge object, or null");
+        } else {
             RectangleEdge edge = (RectangleEdge) key;
             if (edge == RectangleEdge.TOP) {
                 this.topBlock = block;

--- a/src/test/java/org/jfree/chart/block/BorderArrangementTest.java
+++ b/src/test/java/org/jfree/chart/block/BorderArrangementTest.java
@@ -66,9 +66,30 @@ public class BorderArrangementTest  {
 
     private static final double EPSILON = 0.0000000001;
 
+    /**
+     * Test the contract that adding the wrong object type throws an
+     * <tt>IllegalArgumentException</tt>
+     */
+    @Test(expected=IllegalArgumentException.class)
+    public void testAddWrongEdgeType() {
+    	BorderArrangement b1 = new BorderArrangement();
+    	b1.add(new EmptyBlock(1.0, 1.0), new String("Hello"));
+    }
 
 
-
+    /**
+     * Test the contract that adding the correct object type (any
+     * one of the RectangleEdge enumerations) works and does not
+     * throw an exception
+     */
+    @Test
+    public void testAddCorrectEdgeType() {
+    	BorderArrangement b1 = new BorderArrangement();
+    	b1.add(new EmptyBlock(1.0, 1.0), RectangleEdge.TOP);
+    	b1.add(new EmptyBlock(1.0, 1.0), RectangleEdge.BOTTOM);
+    	b1.add(new EmptyBlock(1.0, 1.0), RectangleEdge.LEFT);
+    	b1.add(new EmptyBlock(1.0, 1.0), RectangleEdge.RIGHT);
+    }
 
     /**
      * Confirm that the equals() method can distinguish all the required fields.


### PR DESCRIPTION
...e

This commit fixes the issue as described in http://sourceforge.net/p/jfreechart/bugs/1084/. The "add" method in BorderArrangement first checks if the object passed in is null, and if not, then immediately casts it to a RectangleEdge. If the object is not a Rectangle edge, then a ClassCastException is thrown as described by the author of bug 1084. I've added a condition which checks if the object passed in is not an instance of RectangleEdge. If it is not, then an IllegalArgumentException is thrown, which is more appropriate. 

There is no risk here to client code since RectangleEdge is an enumeration, and thus cannot be extended. Also included are two unit tests which verify the contract. 
