### PR TITLE
Fix bug 1109 - Color of a zero-value middle bar in a Waterfall chart 

### DIFF
--- a/src/main/java/org/jfree/chart/renderer/category/WaterfallBarRenderer.java
+++ b/src/main/java/org/jfree/chart/renderer/category/WaterfallBarRenderer.java
@@ -401,24 +401,9 @@ public class WaterfallBarRenderer extends BarRenderer {
         }
         Rectangle2D bar = new Rectangle2D.Double(rectX, rectY, rectWidth,
                 rectHeight);
-        Paint seriesPaint;
-        if (column == 0) {
-            seriesPaint = getFirstBarPaint();
-        }
-        else if (column == categoryCount - 1) {
-            seriesPaint = getLastBarPaint();
-        }
-        else {
-            if (valDiff < 0.0) {
-                seriesPaint = getNegativeBarPaint();
-            }
-            else if (valDiff > 0.0) {
-                seriesPaint = getPositiveBarPaint();
-            }
-            else {
-                seriesPaint = getLastBarPaint();
-            }
-        }
+        
+        Paint seriesPaint = getSeriesPaintObject(column, categoryCount, valDiff);
+       
         if (getGradientPaintTransformer() != null
                 && seriesPaint instanceof GradientPaint) {
             GradientPaint gp = (GradientPaint) seriesPaint;
@@ -453,6 +438,37 @@ public class WaterfallBarRenderer extends BarRenderer {
         }
 
     }
+    
+    /**
+     * Returns the appropriate paint object depending on three things: the current
+     * column, the category count, and the value difference. 
+     *
+     * @param column  the current column which is being evaluated (0 based)
+     * @param categoryCount  the category in the dataset, used to determine if we are 
+     *                       on the last column 
+     * @param valDiff  the numerical difference for that column. 
+     *                   
+     *
+     * @return <code>Paint</code> object corresponding to current column.
+     */
+	Paint getSeriesPaintObject(int column, int categoryCount, double valDiff) {
+		Paint seriesPaint;
+		if (column == 0) {
+            seriesPaint = getFirstBarPaint();
+        }
+        else if (column == categoryCount - 1) {
+            seriesPaint = getLastBarPaint();
+        }
+        else {
+            if (valDiff < 0.0) {
+                seriesPaint = getNegativeBarPaint();
+            }
+            else {
+                seriesPaint = getPositiveBarPaint();
+            }
+        }
+		return seriesPaint;
+	}    
 
     /**
      * Tests an object for equality with this instance.

--- a/src/test/java/org/jfree/chart/renderer/category/WaterfallBarRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/category/WaterfallBarRendererTest.java
@@ -66,10 +66,6 @@ import static org.junit.Assert.assertTrue;
  */
 public class WaterfallBarRendererTest  {
 
-
-
-
-
     /**
      * Some tests for the findRangeBounds() method.
      */
@@ -177,5 +173,44 @@ public class WaterfallBarRendererTest  {
         assertEquals(r1, r2);
 
     }
+    
+    /**
+     * Check that the paint object returned for a middle column with 0 
+     * difference is the positive bar paint object
+     */
+	@Test
+	public void testGetSeriesPaintForDifferentValues() {
+		Color firstPaint = Color.cyan;
+		Color positivePaint = Color.green;
+		Color negativePaint = Color.red;
+		Color lastPaint = Color.blue;
+		WaterfallBarRenderer waterfallBarRenderer = new WaterfallBarRenderer(firstPaint, positivePaint, negativePaint, lastPaint);
 
+		// Sets of tests for making sure the correct paint object is returned
+		// for different scenarios. 
+		
+		// In the first set, the "firstPaint" object is always returned because
+		// this is first column (regardless of the value of the value difference).
+		assertSame(firstPaint, waterfallBarRenderer.getSeriesPaintObject(0, 1, 0d));
+		assertSame(firstPaint, waterfallBarRenderer.getSeriesPaintObject(0, 2, 1d));
+		assertSame(firstPaint, waterfallBarRenderer.getSeriesPaintObject(0, 2, -1d));
+
+		// In the second set, the "positivePaint" object is returned for middle
+		// columns which are greater than or equal to 0. 
+		assertSame(positivePaint, waterfallBarRenderer.getSeriesPaintObject(1, 1, 1d));
+		assertSame(positivePaint, waterfallBarRenderer.getSeriesPaintObject(1, 1, 0d));
+		assertSame(positivePaint, waterfallBarRenderer.getSeriesPaintObject(1, 3, 0d));
+
+		// In the third set, the "negativePaint" object is returned for middle 
+		// columns which are less than zero.
+		assertSame(negativePaint, waterfallBarRenderer.getSeriesPaintObject(1, 1, -0.5d));
+		assertSame(negativePaint, waterfallBarRenderer.getSeriesPaintObject(1, 3, -0.5d));
+		assertSame(negativePaint, waterfallBarRenderer.getSeriesPaintObject(1, 0, -0.5d));
+		
+		// In the last set, the "lastPaint" object is returned because this is the 
+		// last column (regardless of the value of the value difference).
+		assertSame(lastPaint, waterfallBarRenderer.getSeriesPaintObject(1, 2, 0d));
+		assertSame(lastPaint, waterfallBarRenderer.getSeriesPaintObject(1, 2, 1d));
+		assertSame(lastPaint, waterfallBarRenderer.getSeriesPaintObject(1, 2, -1d));
+	}
 }


### PR DESCRIPTION
This pull request fixes the bug as described in http://sourceforge.net/p/jfreechart/bugs/1109/. The issue was that in the WaterfallBarRenderer class, a middle column having a value of 0 would be rendered using the wrong Paint object for the series. When viewing a JPEG image of the chart, it was evident that the color of the zero-value bar was the same as the last bar. My colleague Dimitri and I added steps in the bug report to show how to reproduce the issue. 

The source of the issue was method "drawItem(...)" in class WaterfallBarRenderer. For middle columns, the valDiff variable was verified. If less than 0, then it was colored using the negative bar paint object; if greater than 0, it was colored using the positive bar paint object; otherwise (exactly zero-value), it was colored using the last bar paint object. 

In order to fix this issue, we refactored out a (package private) method called "getSeriesPaintObject" which takes in the column number, the category count number, and the value difference for the column. This enabled us to isolate the change, and to build some unit tests to verify our assumption. Essentially, the logic is now as follows:

1) The first column gets the color from "getFirstBarPaint()"
2) The last column gets the color from "getLastBarPaint()"
3) Middle columns get the color depending on the value difference. If negative, "getNegativeBarPaint()" is called. If positive (and zero), "getPositiveBarPaint()" is called.

This pull request contains the changes to the "WaterfallBarRenderer" class, and the addition of a new test in "WaterfallBarRendererTest" which verifies the cases mentioned above. . 
