### PR TITLE
WaferMapDataset and WaferMapPlot can now handle negative coordinates

### DIFF
--- a/src/main/java/org/jfree/chart/plot/WaferMapPlot.java
+++ b/src/main/java/org/jfree/chart/plot/WaferMapPlot.java
@@ -44,9 +44,9 @@
  *               Jess Thrysoee (DG);
  * 17-Jun-2012 : Removed JCommon dependencies (DG);
  * 10-Mar-2014 : Removed LegendItemCollection (DG);
- *
+ * ------------- FSE ----------------------------------------------------------
+ * 14-Feb-2015 : Modified to deal with raw coordinates (FF)
  */
-
 package org.jfree.chart.plot;
 
 import java.awt.BasicStroke;
@@ -63,12 +63,11 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.ResourceBundle;
 import org.jfree.chart.LegendItem;
-
-import org.jfree.chart.ui.RectangleInsets;
 import org.jfree.chart.event.PlotChangeEvent;
 import org.jfree.chart.event.RendererChangeEvent;
 import org.jfree.chart.event.RendererChangeListener;
 import org.jfree.chart.renderer.WaferMapRenderer;
+import org.jfree.chart.ui.RectangleInsets;
 import org.jfree.chart.util.ResourceBundleWrapper;
 import org.jfree.data.general.DatasetChangeEvent;
 import org.jfree.data.general.WaferMapDataset;
@@ -79,47 +78,62 @@ import org.jfree.data.general.WaferMapDataset;
 public class WaferMapPlot extends Plot implements RendererChangeListener,
         Cloneable, Serializable {
 
-    /** For serialization. */
+    /**
+     * For serialization.
+     */
     private static final long serialVersionUID = 4668320403707308155L;
 
-    /** The default grid line stroke. */
+    /**
+     * The default grid line stroke.
+     */
     public static final Stroke DEFAULT_GRIDLINE_STROKE = new BasicStroke(0.5f,
-        BasicStroke.CAP_BUTT,
-        BasicStroke.JOIN_BEVEL,
-        0.0f,
-        new float[] {2.0f, 2.0f},
-        0.0f);
+            BasicStroke.CAP_BUTT,
+            BasicStroke.JOIN_BEVEL,
+            0.0f,
+            new float[]{2.0f, 2.0f},
+            0.0f);
 
-    /** The default grid line paint. */
+    /**
+     * The default grid line paint.
+     */
     public static final Paint DEFAULT_GRIDLINE_PAINT = Color.LIGHT_GRAY;
 
-    /** The default crosshair visibility. */
+    /**
+     * The default crosshair visibility.
+     */
     public static final boolean DEFAULT_CROSSHAIR_VISIBLE = false;
 
-    /** The default crosshair stroke. */
+    /**
+     * The default crosshair stroke.
+     */
     public static final Stroke DEFAULT_CROSSHAIR_STROKE
             = DEFAULT_GRIDLINE_STROKE;
 
-    /** The default crosshair paint. */
+    /**
+     * The default crosshair paint.
+     */
     public static final Paint DEFAULT_CROSSHAIR_PAINT = Color.BLUE;
 
-    /** The resourceBundle for the localization. */
+    /**
+     * The resourceBundle for the localization.
+     */
     protected static ResourceBundle localizationResources
             = ResourceBundleWrapper.getBundle(
                     "org.jfree.chart.plot.LocalizationBundle");
 
-    /** The plot orientation.
-     *  vertical = notch down
-     *  horizontal = notch right
+    /**
+     * The plot orientation. vertical = notch down horizontal = notch right
      */
     private PlotOrientation orientation;
 
-    /** The dataset. */
+    /**
+     * The dataset.
+     */
     private WaferMapDataset dataset;
 
     /**
-     * Object responsible for drawing the visual representation of each point
-     * on the plot.
+     * Object responsible for drawing the visual representation of each point on
+     * the plot.
      */
     private WaferMapRenderer renderer;
 
@@ -133,7 +147,7 @@ public class WaferMapPlot extends Plot implements RendererChangeListener,
     /**
      * Creates a new plot.
      *
-     * @param dataset  the dataset (<code>null</code> permitted).
+     * @param dataset the dataset (<code>null</code> permitted).
      */
     public WaferMapPlot(WaferMapDataset dataset) {
         this(dataset, null);
@@ -142,8 +156,8 @@ public class WaferMapPlot extends Plot implements RendererChangeListener,
     /**
      * Creates a new plot.
      *
-     * @param dataset  the dataset (<code>null</code> permitted).
-     * @param renderer  the renderer (<code>null</code> permitted).
+     * @param dataset the dataset (<code>null</code> permitted).
+     * @param renderer the renderer (<code>null</code> permitted).
      */
     public WaferMapPlot(WaferMapDataset dataset, WaferMapRenderer renderer) {
 
@@ -184,10 +198,10 @@ public class WaferMapPlot extends Plot implements RendererChangeListener,
     }
 
     /**
-     * Sets the dataset used by the plot and sends a {@link PlotChangeEvent}
-     * to all registered listeners.
+     * Sets the dataset used by the plot and sends a {@link PlotChangeEvent} to
+     * all registered listeners.
      *
-     * @param dataset  the dataset (<code>null</code> permitted).
+     * @param dataset the dataset (<code>null</code> permitted).
      */
     public void setDataset(WaferMapDataset dataset) {
         // if there is an existing dataset, remove the plot from the list of
@@ -208,10 +222,10 @@ public class WaferMapPlot extends Plot implements RendererChangeListener,
 
     /**
      * Sets the item renderer, and notifies all listeners of a change to the
-     * plot.  If the renderer is set to <code>null</code>, no chart will be
+     * plot. If the renderer is set to <code>null</code>, no chart will be
      * drawn.
      *
-     * @param renderer  the new renderer (<code>null</code> permitted).
+     * @param renderer the new renderer (<code>null</code> permitted).
      */
     public void setRenderer(WaferMapRenderer renderer) {
         if (this.renderer != null) {
@@ -227,16 +241,16 @@ public class WaferMapPlot extends Plot implements RendererChangeListener,
     /**
      * Draws the wafermap view.
      *
-     * @param g2  the graphics device.
-     * @param area  the plot area.
-     * @param anchor  the anchor point (<code>null</code> permitted).
-     * @param state  the plot state.
-     * @param info  the plot rendering info.
+     * @param g2 the graphics device.
+     * @param area the plot area.
+     * @param anchor the anchor point (<code>null</code> permitted).
+     * @param state the plot state.
+     * @param info the plot rendering info.
      */
     @Override
     public void draw(Graphics2D g2, Rectangle2D area, Point2D anchor,
-                     PlotState state,
-                     PlotRenderingInfo info) {
+            PlotState state,
+            PlotRenderingInfo info) {
 
         // if the plot area is too small, just return...
         boolean b1 = (area.getWidth() <= MINIMUM_WIDTH_TO_DRAW);
@@ -262,8 +276,8 @@ public class WaferMapPlot extends Plot implements RendererChangeListener,
     /**
      * Calculates and draws the chip locations on the wafer.
      *
-     * @param g2  the graphics device.
-     * @param plotArea  the plot area.
+     * @param g2 the graphics device.
+     * @param plotArea the plot area.
      */
     protected void drawChipGrid(Graphics2D g2, Rectangle2D plotArea) {
 
@@ -274,8 +288,10 @@ public class WaferMapPlot extends Plot implements RendererChangeListener,
         int ychips = 20;
         double space = 1d;
         if (this.dataset != null) {
-            xchips = this.dataset.getMaxChipX() + 2;
-            ychips = this.dataset.getMaxChipY() + 2;
+            xchips = (this.dataset.getMaxChipX()
+                    - this.dataset.getMinChipX()) + 2;
+            ychips = (this.dataset.getMaxChipY()
+                    - this.dataset.getMinChipY()) + 2;
             space = this.dataset.getChipSpace();
         }
         double startX = plotArea.getX();
@@ -287,8 +303,7 @@ public class WaferMapPlot extends Plot implements RendererChangeListener,
             if (plotArea.getWidth() > plotArea.getHeight()) {
                 major = plotArea.getWidth();
                 minor = plotArea.getHeight();
-            }
-            else {
+            } else {
                 major = plotArea.getHeight();
                 minor = plotArea.getWidth();
             }
@@ -296,32 +311,31 @@ public class WaferMapPlot extends Plot implements RendererChangeListener,
             if (plotArea.getWidth() == minor) { // x is minor
                 startY += (major - minor) / 2;
                 chipWidth = (plotArea.getWidth() - (space * xchips - 1))
-                    / xchips;
+                        / xchips;
                 chipHeight = (plotArea.getWidth() - (space * ychips - 1))
-                    / ychips;
-            }
-            else { // y is minor
+                        / ychips;
+            } else { // y is minor
                 startX += (major - minor) / 2;
                 chipWidth = (plotArea.getHeight() - (space * xchips - 1))
-                    / xchips;
+                        / xchips;
                 chipHeight = (plotArea.getHeight() - (space * ychips - 1))
-                    / ychips;
+                        / ychips;
             }
         }
 
         for (int x = 1; x <= xchips; x++) {
             double upperLeftX = (startX - chipWidth) + (chipWidth * x)
-                + (space * (x - 1));
+                    + (space * (x - 1));
             for (int y = 1; y <= ychips; y++) {
                 double upperLeftY = (startY - chipHeight) + (chipHeight * y)
-                    + (space * (y - 1));
+                        + (space * (y - 1));
                 chip.setFrame(upperLeftX, upperLeftY, chipWidth, chipHeight);
                 g2.setColor(Color.WHITE);
                 if (this.dataset.getChipValue(x - 1, ychips - y - 1) != null) {
                     g2.setPaint(
-                        this.renderer.getChipColor(
-                            this.dataset.getChipValue(x - 1, ychips - y - 1)
-                        )
+                            this.renderer.getChipColor(
+                                    this.dataset.getChipValue(x - 1, ychips - y - 1)
+                            )
                     );
                 }
                 g2.fill(chip);
@@ -335,7 +349,7 @@ public class WaferMapPlot extends Plot implements RendererChangeListener,
     /**
      * Calculates the location of the waferedge.
      *
-     * @param plotArea  the plot area.
+     * @param plotArea the plot area.
      *
      * @return The wafer edge.
      */
@@ -350,8 +364,7 @@ public class WaferMapPlot extends Plot implements RendererChangeListener,
             if (plotArea.getWidth() > plotArea.getHeight()) {
                 major = plotArea.getWidth();
                 minor = plotArea.getHeight();
-            }
-            else {
+            } else {
                 major = plotArea.getHeight();
                 minor = plotArea.getWidth();
             }
@@ -360,8 +373,7 @@ public class WaferMapPlot extends Plot implements RendererChangeListener,
             //set upperLeft point
             if (plotArea.getWidth() == minor) { // x is minor
                 upperLeftY = plotArea.getY() + (major - minor) / 2;
-            }
-            else { // y is minor
+            } else { // y is minor
                 upperLeftX = plotArea.getX() + (major - minor) / 2;
             }
         }
@@ -372,8 +384,8 @@ public class WaferMapPlot extends Plot implements RendererChangeListener,
     /**
      * Draws the waferedge, including the notch.
      *
-     * @param g2  the graphics device.
-     * @param plotArea  the plot area.
+     * @param g2 the graphics device.
+     * @param plotArea the plot area.
      */
     protected void drawWaferEdge(Graphics2D g2, Rectangle2D plotArea) {
         // draw the wafer
@@ -387,23 +399,22 @@ public class WaferMapPlot extends Plot implements RendererChangeListener,
         Rectangle2D waferFrame = waferEdge.getFrame();
         double notchDiameter = waferFrame.getWidth() * 0.04;
         if (this.orientation == PlotOrientation.HORIZONTAL) {
-            Rectangle2D notchFrame =
-                new Rectangle2D.Double(
-                    waferFrame.getX() + waferFrame.getWidth()
-                    - (notchDiameter / 2), waferFrame.getY()
-                    + (waferFrame.getHeight() / 2) - (notchDiameter / 2),
-                    notchDiameter, notchDiameter
-                );
+            Rectangle2D notchFrame
+                    = new Rectangle2D.Double(
+                            waferFrame.getX() + waferFrame.getWidth()
+                            - (notchDiameter / 2), waferFrame.getY()
+                            + (waferFrame.getHeight() / 2) - (notchDiameter / 2),
+                            notchDiameter, notchDiameter
+                    );
             notch = new Arc2D.Double(notchFrame, 90d, 180d, Arc2D.OPEN);
-        }
-        else {
-            Rectangle2D notchFrame =
-                new Rectangle2D.Double(
-                    waferFrame.getX() + (waferFrame.getWidth() / 2)
-                    - (notchDiameter / 2), waferFrame.getY()
-                    + waferFrame.getHeight() - (notchDiameter / 2),
-                    notchDiameter, notchDiameter
-                );
+        } else {
+            Rectangle2D notchFrame
+                    = new Rectangle2D.Double(
+                            waferFrame.getX() + (waferFrame.getWidth() / 2)
+                            - (notchDiameter / 2), waferFrame.getY()
+                            + waferFrame.getHeight() - (notchDiameter / 2),
+                            notchDiameter, notchDiameter
+                    );
             notch = new Arc2D.Double(notchFrame, 0d, 180d, Arc2D.OPEN);
         }
         g2.setColor(Color.WHITE);
@@ -426,7 +437,7 @@ public class WaferMapPlot extends Plot implements RendererChangeListener,
     /**
      * Notifies all registered listeners of a renderer change.
      *
-     * @param event  the event.
+     * @param event the event.
      */
     @Override
     public void rendererChanged(RendererChangeEvent event) {

--- a/src/main/java/org/jfree/chart/renderer/WaferMapRenderer.java
+++ b/src/main/java/org/jfree/chart/renderer/WaferMapRenderer.java
@@ -40,9 +40,7 @@
  * ------------- JFREECHART 1.0.x ---------------------------------------------
  * 02-Feb-2007 : Removed author tags from all over JFreeChart sources (DG);
  * 10-Mar-2014 : Removed LegendItemCollection (DG);
- * 
  */
-
 package org.jfree.chart.renderer;
 
 import java.awt.Color;
@@ -56,36 +54,49 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import org.jfree.chart.LegendItem;
 import org.jfree.chart.plot.DrawingSupplier;
 import org.jfree.chart.plot.WaferMapPlot;
 import org.jfree.data.general.WaferMapDataset;
 
 /**
- * A renderer for wafer map plots.  Provides color management facilities.
+ * A renderer for wafer map plots. Provides color management facilities.
  */
 public class WaferMapRenderer extends AbstractRenderer {
 
-    /** paint index */
+    /**
+     * paint index
+     */
     private Map<Number, Integer> paintIndex;
 
-    /** plot */
+    /**
+     * plot
+     */
     private WaferMapPlot plot;
 
-    /** paint limit */
+    /**
+     * paint limit
+     */
     private int paintLimit;
 
-    /** default paint limit */
+    /**
+     * default paint limit
+     */
     private static final int DEFAULT_PAINT_LIMIT = 35;
 
-    /** default multivalue paint calculation */
+    /**
+     * default multivalue paint calculation
+     */
     public static final int POSITION_INDEX = 0;
 
-    /** The default value index. */
+    /**
+     * The default value index.
+     */
     public static final int VALUE_INDEX = 1;
 
-    /** paint index method */
+    /**
+     * paint index method
+     */
     private int paintIndexMethod;
 
     /**
@@ -98,8 +109,8 @@ public class WaferMapRenderer extends AbstractRenderer {
     /**
      * Creates a new renderer.
      *
-     * @param paintLimit  the paint limit.
-     * @param paintIndexMethod  the paint index method.
+     * @param paintLimit the paint limit.
+     * @param paintIndexMethod the paint index method.
      */
     public WaferMapRenderer(Integer paintLimit, Integer paintIndexMethod) {
 
@@ -108,8 +119,7 @@ public class WaferMapRenderer extends AbstractRenderer {
 
         if (paintLimit == null) {
             this.paintLimit = DEFAULT_PAINT_LIMIT;
-        }
-        else {
+        } else {
             this.paintLimit = paintLimit;
         }
 
@@ -124,15 +134,18 @@ public class WaferMapRenderer extends AbstractRenderer {
     /**
      * Verifies that the passed paint index method is valid.
      *
-     * @param method  the method.
+     * @param method the method.
      *
      * @return <code>true</code> or </code>false</code>.
      */
     private boolean isMethodValid(int method) {
         switch (method) {
-            case POSITION_INDEX: return true;
-            case VALUE_INDEX:    return true;
-            default: return false;
+            case POSITION_INDEX:
+                return true;
+            case VALUE_INDEX:
+                return true;
+            default:
+                return false;
         }
     }
 
@@ -163,7 +176,7 @@ public class WaferMapRenderer extends AbstractRenderer {
     /**
      * Sets the plot and build the paint index.
      *
-     * @param plot  the plot.
+     * @param plot the plot.
      */
     public void setPlot(WaferMapPlot plot) {
         this.plot = plot;
@@ -173,7 +186,7 @@ public class WaferMapRenderer extends AbstractRenderer {
     /**
      * Returns the paint for a given chip value.
      *
-     * @param value  the value.
+     * @param value the value.
      *
      * @return The paint.
      */
@@ -184,7 +197,7 @@ public class WaferMapRenderer extends AbstractRenderer {
     /**
      * Returns the paint index for a given chip value.
      *
-     * @param value  the value.
+     * @param value the value.
      *
      * @return The paint index.
      */
@@ -193,8 +206,8 @@ public class WaferMapRenderer extends AbstractRenderer {
     }
 
     /**
-     * Builds a map of chip values to paint colors.
-     * paintlimit is the maximum allowed number of colors.
+     * Builds a map of chip values to paint colors. paintlimit is the maximum
+     * allowed number of colors.
      */
     private void makePaintIndex() {
         if (this.plot == null) {
@@ -209,8 +222,7 @@ public class WaferMapRenderer extends AbstractRenderer {
             for (Number uniqueValue : uniqueValues) {
                 this.paintIndex.put(uniqueValue, count++);
             }
-        }
-        else {
+        } else {
             // more values than paints so map
             // multiple values to the same color
             switch (this.paintIndexMethod) {
@@ -227,14 +239,14 @@ public class WaferMapRenderer extends AbstractRenderer {
     }
 
     /**
-     * Builds the paintindex by assigning colors based on the number
-     * of unique values: totalvalues/totalcolors.
+     * Builds the paintindex by assigning colors based on the number of unique
+     * values: totalvalues/totalcolors.
      *
-     * @param uniqueValues  the set of unique values.
+     * @param uniqueValues the set of unique values.
      */
     private void makePositionIndex(Set<Number> uniqueValues) {
         int valuesPerColor = (int) Math.ceil(
-            (double) uniqueValues.size() / this.paintLimit
+                (double) uniqueValues.size() / this.paintLimit
         );
         int count = 0; // assign a color for each unique value
         int paint = 0;
@@ -250,12 +262,12 @@ public class WaferMapRenderer extends AbstractRenderer {
     }
 
     /**
-     * Builds the paintindex by assigning colors evenly across the range
-     * of values:  maxValue-minValue/totalcolors
+     * Builds the paintindex by assigning colors evenly across the range of
+     * values: maxValue-minValue/totalcolors
      *
-     * @param max  the maximum value.
-     * @param min  the minumum value.
-     * @param uniqueValues  the unique values.
+     * @param max the maximum value.
+     * @param min the minumum value.
+     * @param uniqueValues the unique values.
      */
     private void makeValueIndex(Number max, Number min, Set<Number> uniqueValues) {
         double valueRange = max.doubleValue() - min.doubleValue();
@@ -275,7 +287,7 @@ public class WaferMapRenderer extends AbstractRenderer {
     }
 
     /**
-     * Builds the list of legend entries.  called by getLegendItems in
+     * Builds the list of legend entries. called by getLegendItems in
      * WaferMapPlot to populate the plot legend.
      *
      * @return The legend items.
@@ -298,8 +310,7 @@ public class WaferMapRenderer extends AbstractRenderer {
                             null, shape, paint, outlineStroke, outlinePaint));
 
                 }
-            }
-            else {
+            } else {
                 // in this case, every color has a range of values
                 Set<Integer> unique = new HashSet<Integer>();
                 for (Map.Entry<Number, Integer> entry : this.paintIndex.entrySet()) {
@@ -307,7 +318,7 @@ public class WaferMapRenderer extends AbstractRenderer {
                         String label = getMinPaintValue(
                                 entry.getValue()).toString()
                                 + " - " + getMaxPaintValue(
-                                entry.getValue()).toString();
+                                        entry.getValue()).toString();
                         String description = label;
                         Shape shape = new Rectangle2D.Double(1d, 1d, 1d, 1d);
                         Paint paint = getSeriesPaint(
@@ -327,10 +338,9 @@ public class WaferMapRenderer extends AbstractRenderer {
     }
 
     /**
-     * Returns the minimum chip value assigned to a color
-     * in the paintIndex
+     * Returns the minimum chip value assigned to a color in the paintIndex
      *
-     * @param index  the index.
+     * @param index the index.
      *
      * @return The value.
      */
@@ -347,10 +357,9 @@ public class WaferMapRenderer extends AbstractRenderer {
     }
 
     /**
-     * Returns the maximum chip value assigned to a color
-     * in the paintIndex
+     * Returns the maximum chip value assigned to a color in the paintIndex
      *
-     * @param index  the index.
+     * @param index the index.
      *
      * @return The value
      */
@@ -365,6 +374,5 @@ public class WaferMapRenderer extends AbstractRenderer {
         }
         return maxValue;
     }
-
 
 } // end class wafermaprenderer

--- a/src/main/java/org/jfree/data/general/WaferMapDataset.java
+++ b/src/main/java/org/jfree/data/general/WaferMapDataset.java
@@ -39,13 +39,14 @@
  * ------------- JFREECHART 1.0.x ---------------------------------------------
  * 02-Feb-2007 : Removed author tags from all over JFreeChart sources (DG);
  *
+ * ------------- FSE ----------------------------------------------------------
+ * 14-Feb-2015 : New constructor for "raw" coordinates (which may
+ *               be negative) (FF);
  */
-
 package org.jfree.data.general;
 
 import java.util.Set;
 import java.util.TreeSet;
-
 import org.jfree.data.DefaultKeyedValues2D;
 
 /**
@@ -55,34 +56,55 @@ import org.jfree.data.DefaultKeyedValues2D;
 public class WaferMapDataset extends AbstractDataset {
 
     /**
-     * Storage structure for the data values (row key is chipx, column is
-     * chipy)
+     * Storage structure for the data values (row key is chipx, column is chipy)
      */
     private DefaultKeyedValues2D data;
 
-    /** wafer x dimension */
+    /**
+     * wafer x dimension
+     */
     private int maxChipX;
 
-    /** wafer y dimension */
+    /**
+     * wafer y dimension
+     */
     private int maxChipY;
 
-    /** space to draw between chips */
+    /**
+     * minimum wafer x dimension. Defaults to 0
+     */
+    private int minChipX = 0;
+
+    /**
+     * minimum wafer y dimension. Defaults to 0
+     */
+    private int minChipY = 0;
+
+    /**
+     * space to draw between chips
+     */
     private double chipSpace;
 
-    /** maximum value in this dataset */
+    /**
+     * maximum value in this dataset
+     */
     private Double maxValue;
 
-    /** minimum value in this dataset */
+    /**
+     * minimum value in this dataset
+     */
     private Double minValue;
 
-    /** default chip spacing */
+    /**
+     * default chip spacing
+     */
     private static final double DEFAULT_CHIP_SPACE = 1d;
 
     /**
      * Creates a new dataset using the default chipspace.
      *
-     * @param maxChipX  the wafer x-dimension.
-     * @param maxChipY  the wafer y-dimension.
+     * @param maxChipX the wafer x-dimension.
+     * @param maxChipY the wafer y-dimension.
      */
     public WaferMapDataset(int maxChipX, int maxChipY) {
         this(maxChipX, maxChipY, null);
@@ -91,9 +113,9 @@ public class WaferMapDataset extends AbstractDataset {
     /**
      * Creates a new dataset.
      *
-     * @param maxChipX  the wafer x-dimension.
-     * @param maxChipY  the wafer y-dimension.
-     * @param chipSpace  the space between chips.
+     * @param maxChipX the wafer x-dimension.
+     * @param maxChipY the wafer y-dimension.
+     * @param chipSpace the space between chips.
      */
     public WaferMapDataset(int maxChipX, int maxChipY, Number chipSpace) {
 
@@ -103,10 +125,42 @@ public class WaferMapDataset extends AbstractDataset {
 
         this.maxChipX = maxChipX;
         this.maxChipY = maxChipY;
+
         if (chipSpace == null) {
             this.chipSpace = DEFAULT_CHIP_SPACE;
+        } else {
+            this.chipSpace = chipSpace.doubleValue();
         }
-        else {
+
+    }
+
+    /**
+     * Creates a new dataset.
+     *
+     * @param minChipX The minimum x coordinate.
+     * @param maxChipX The maximum x coordinate.
+     * @param minChipY The minimum y coordinate.
+     * @param maxChipY The maximum y coordinate.
+     * @param chipSpace The space between chips.
+     */
+    public WaferMapDataset(int minChipX, int maxChipX,
+            int minChipY, int maxChipY,
+            Number chipSpace) {
+
+        this.maxValue = Double.NEGATIVE_INFINITY;
+        this.minValue = Double.POSITIVE_INFINITY;
+        this.data = new DefaultKeyedValues2D();
+
+        this.maxChipX = maxChipX;
+        this.maxChipY = maxChipY;
+
+        // Store the minimum coordinate
+        this.minChipX = minChipX;
+        this.minChipY = minChipY;
+
+        if (chipSpace == null) {
+            this.chipSpace = DEFAULT_CHIP_SPACE;
+        } else {
             this.chipSpace = chipSpace.doubleValue();
         }
 
@@ -115,9 +169,9 @@ public class WaferMapDataset extends AbstractDataset {
     /**
      * Sets a value in the dataset.
      *
-     * @param value  the value.
-     * @param chipx  the x-index for the chip.
-     * @param chipy  the y-index for the chip.
+     * @param value the value.
+     * @param chipx the x-index for the chip.
+     * @param chipy the y-index for the chip.
      */
     public void addValue(Number value, Comparable chipx, Comparable chipy) {
         setValue(value, chipx, chipy);
@@ -126,9 +180,9 @@ public class WaferMapDataset extends AbstractDataset {
     /**
      * Adds a value to the dataset.
      *
-     * @param v  the value.
-     * @param x  the x-index.
-     * @param y  the y-index.
+     * @param v the value.
+     * @param x the x-index.
+     * @param y the y-index.
      */
     public void addValue(int v, int x, int y) {
         setValue((double) v, x, y);
@@ -137,12 +191,13 @@ public class WaferMapDataset extends AbstractDataset {
     /**
      * Sets a value in the dataset and updates min and max value entries.
      *
-     * @param value  the value.
-     * @param chipx  the x-index.
-     * @param chipy  the y-index.
+     * @param value the value.
+     * @param chipx the x-index.
+     * @param chipy the y-index.
      */
     public void setValue(Number value, Comparable chipx, Comparable chipy) {
         this.data.setValue(value, chipx, chipy);
+
         if (isMaxValue(value)) {
             this.maxValue = (Double) value;
         }
@@ -182,8 +237,8 @@ public class WaferMapDataset extends AbstractDataset {
     /**
      * Returns the data value for a chip.
      *
-     * @param chipx  the x-index.
-     * @param chipy  the y-index.
+     * @param chipx the x-index.
+     * @param chipy the y-index.
      *
      * @return The data value.
      */
@@ -194,8 +249,8 @@ public class WaferMapDataset extends AbstractDataset {
     /**
      * Returns the value for a given chip x and y or null.
      *
-     * @param chipx  the x-index.
-     * @param chipy  the y-index.
+     * @param chipx the x-index.
+     * @param chipy the y-index.
      *
      * @return The data value.
      */
@@ -214,7 +269,7 @@ public class WaferMapDataset extends AbstractDataset {
     /**
      * Tests to see if the passed value is larger than the stored maxvalue.
      *
-     * @param check  the number to check.
+     * @param check the number to check.
      *
      * @return A boolean.
      */
@@ -228,7 +283,7 @@ public class WaferMapDataset extends AbstractDataset {
     /**
      * Tests to see if the passed value is smaller than the stored minvalue.
      *
-     * @param check  the number to check.
+     * @param check the number to check.
      *
      * @return A boolean.
      */
@@ -269,7 +324,7 @@ public class WaferMapDataset extends AbstractDataset {
     /**
      * Sets wafer x dimension.
      *
-     * @param maxChipX  the number of chips in the x-dimension.
+     * @param maxChipX the number of chips in the x-dimension.
      */
     public void setMaxChipX(int maxChipX) {
         this.maxChipX = maxChipX;
@@ -287,7 +342,7 @@ public class WaferMapDataset extends AbstractDataset {
     /**
      * Sets the number of chips in the y-dimension.
      *
-     * @param maxChipY  the number of chips.
+     * @param maxChipY the number of chips.
      */
     public void setMaxChipY(int maxChipY) {
         this.maxChipY = maxChipY;
@@ -305,10 +360,46 @@ public class WaferMapDataset extends AbstractDataset {
     /**
      * Sets the space to draw between chips.
      *
-     * @param space  the space.
+     * @param space the space.
      */
     public void setChipSpace(double space) {
         this.chipSpace = space;
+    }
+
+    /**
+     * Gets the min x coordinate.
+     *
+     * @return Minimum X coordinate
+     */
+    public int getMinChipX() {
+        return this.minChipX;
+    }
+
+    /**
+     * Gets the min y coordinate.
+     *
+     * @return Minimum Y coordinate
+     */
+    public int getMinChipY() {
+        return this.minChipY;
+    }
+
+    /**
+     * Sets the minimum chip coordinate along y axis.
+     *
+     * @param minChipY
+     */
+    public void setMinChipY(int minChipY) {
+        this.minChipY = minChipY;
+    }
+
+    /**
+     * Sets the minimum chip coordinate along x axis.
+     *
+     * @param minChipX
+     */
+    public void setMinChipX(int minChipX) {
+        this.minChipX = minChipX;
     }
 
 }


### PR DESCRIPTION
As the <code>WaferMapDataset</code> and the <code>WaferMapPlot</code> can now handle negative coordinates no normalization of coordinates is needed anymore.
Also this modifications allows correct rendering of datasets which do not start at 0/0