### PR TITLE
Fix compile on Java-8 for overridden method that is public, cannot reduce visibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.2</version>
         <configuration>
           <!-- 1.8 is required to compile the JavaFX support. -->
           <source>1.8</source>
@@ -41,7 +42,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.12.4</version>
+        <version>2.18.1</version>
         <configuration>
           <!-- this is here to prevent exceptions being thrown with no message -->
           <!-- or stack trace, which can happen on oracle JVMs after a while   -->
@@ -70,7 +71,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/org/jfree/chart/fx/ChartViewer.java
+++ b/src/main/java/org/jfree/chart/fx/ChartViewer.java
@@ -119,7 +119,7 @@ public class ChartViewer extends Control implements Skinnable,
     }
     
     @Override
-    protected String getUserAgentStylesheet() {
+    public String getUserAgentStylesheet() {
         return ChartViewer.class.getResource("chart-viewer.css")
                 .toExternalForm();
     }

--- a/src/test/java/org/jfree/chart/annotations/package-info.java
+++ b/src/test/java/org/jfree/chart/annotations/package-info.java
@@ -1,4 +1,0 @@
-/**
- * Tests for the classes in the <code>org.jfree.chart.annotations</code> package.
- */
-package org.jfree.chart.annotations;

--- a/src/test/java/org/jfree/chart/axis/package-info.java
+++ b/src/test/java/org/jfree/chart/axis/package-info.java
@@ -1,4 +1,0 @@
-/**
- * Tests for the axis classes and interfaces.
- */
-package org.jfree.chart.axis;

--- a/src/test/java/org/jfree/chart/labels/package-info.java
+++ b/src/test/java/org/jfree/chart/labels/package-info.java
@@ -1,4 +1,0 @@
-/**
- * JUnit tests.
- */
-package org.jfree.chart.labels;

--- a/src/test/java/org/jfree/chart/package-info.java
+++ b/src/test/java/org/jfree/chart/package-info.java
@@ -1,4 +1,0 @@
-/**
- * Test cases for the JFreeChart class library, based on the JUnit framework.
- */
-package org.jfree.chart;

--- a/src/test/java/org/jfree/chart/plot/package-info.java
+++ b/src/test/java/org/jfree/chart/plot/package-info.java
@@ -1,4 +1,0 @@
-/**
- * JUnit tests for the plot classes.
- */
-package org.jfree.chart.plot;

--- a/src/test/java/org/jfree/chart/renderer/package-info.java
+++ b/src/test/java/org/jfree/chart/renderer/package-info.java
@@ -1,4 +1,0 @@
-/**
- * JUnit tests.
- */
-package org.jfree.chart.renderer;

--- a/src/test/java/org/jfree/chart/urls/package-info.java
+++ b/src/test/java/org/jfree/chart/urls/package-info.java
@@ -1,4 +1,0 @@
-/**
- * JUnit tests.
- */
-package org.jfree.chart.urls;

--- a/src/test/java/org/jfree/data/package-info.java
+++ b/src/test/java/org/jfree/data/package-info.java
@@ -1,4 +1,0 @@
-/**
- * Test cases for the classes in com.jfree.data.*.
- */
-package org.jfree.data;

--- a/src/test/java/org/jfree/data/statistics/package-info.java
+++ b/src/test/java/org/jfree/data/statistics/package-info.java
@@ -1,4 +1,0 @@
-/**
- * Tests for the classes in the <code>org.jfree.data.statistics</code> package.
- */
-package org.jfree.data.statistics;

--- a/src/test/java/org/jfree/data/time/package-info.java
+++ b/src/test/java/org/jfree/data/time/package-info.java
@@ -1,4 +1,0 @@
-/**
- * JUnit tests.
- */
-package org.jfree.data.time;


### PR DESCRIPTION
The Java-8 JavaFX method in question may have only recently been changed to public, which may have recently broken the build, but changing it from protected to public fixes the compile failure.

Also removed the src/test/java package-info.java files that are duplicates of the package-info.java files in src/main/java, which Eclipse complains about.

Also add the compiler plugin version to fix Maven warning, and update the surefire and junit versions to the latest available.