### PR TITLE
Improve .gitignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,9 @@
 # Eclipse Files
-bin
 .project
 .classpath
 .settings
 
-
-#IntelliJ IDEA Files
+# IntelliJ IDEA Files
 .idea
 *.iml
 target
-


### PR DESCRIPTION
* Remove `bin` because Eclipse actually builds to `target/classes`
* Remove dangling empty newline
* Remove second newline between sections
* Harmonize section comment formatting